### PR TITLE
chore: set npm publishing access level to `public`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_ACCESS_LEVEL: public
   release_maven:
     name: Publish to Maven Central
     needs: release

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -60,4 +60,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
 });
 
 
+const releaseWorkflow = project.tryFindObjectFile('.github/workflows/release.yml');
+releaseWorkflow.addOverride('jobs.release_npm.steps.6.env.NPM_ACCESS_LEVEL', 'public');
+
 project.synth();


### PR DESCRIPTION
As mentioned in [publib](https://github.com/cdklabs/publib#npm), scoped npm packages that are public need to be published with a `public` access level. 

This is not yet supported directly in projen so we currently escape hatch it. 